### PR TITLE
Remove bones dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rake', require: false
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false
+gem 'test-unit', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,11 @@
-begin
-  require 'bones'
-rescue LoadError
-  abort '### please install the "bones" gem ###'
-end
+# frozen_string_literal: true
 
-ensure_in_path 'lib'
-require 'inifile'
+require "rake/testtask"
 
-task default: 'test:run'
-task 'gem:release' => 'test:run'
+task default: 'test'
 
-Bones do
-  name         'inifile'
-  summary      'INI file reader and writer'
-  authors      'Tim Pease'
-  email        'tim.pease@gmail.com'
-  url          'http://rubygems.org/gems/inifile'
-  version      IniFile::VERSION
-
-  use_gmail
-  depend_on 'bones-git', '~> 1.3', development: true
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/test*.rb']
+  t.verbose = true
 end

--- a/inifile.gemspec
+++ b/inifile.gemspec
@@ -17,7 +17,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'bones',      '~> 3.8'
-  spec.add_development_dependency 'bones-git',  '~> 1.3'
 end


### PR DESCRIPTION
This commit removes the dependency on bones for its testing Rake task and instead adds direct dependencies on Ruby's Rake and Test::Unit modules.